### PR TITLE
Fix weather page css

### DIFF
--- a/src/css/App.css
+++ b/src/css/App.css
@@ -1,6 +1,8 @@
 .App {
   line-height: 1.5;
   height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 h1 {


### PR DESCRIPTION
When viewing the weather page, the height of the content was difficult to traverse.

The Weather component had flex-grow: 1 in its CSS, but the parent container (.App) wasn't set up as a flex container, so the flex-grow property wasn't working.

Before:

<img width="1134" height="924" alt="image" src="https://github.com/user-attachments/assets/348c4d24-34b1-4634-a017-d10e54c54fe8" />


After:

<img width="1115" height="928" alt="image" src="https://github.com/user-attachments/assets/afd5e15b-0870-4fdf-8031-35651a964d52" />
